### PR TITLE
fix: the logic when dns_record_id equals null

### DIFF
--- a/tools/setup-custom-domains/action.yml
+++ b/tools/setup-custom-domains/action.yml
@@ -87,7 +87,7 @@ runs:
                   -H "Content-Type: application/json")
                 dns_record_id=$(echo $getdns | jq -r '.result[0].id')
 
-                if [ -n "$dns_record_id" ]; then
+                if [ -n "$dns_record_id" ] && [ "$dns_record_id" != "null" ]; then
                   echo "Cloudflare dns record for $domain already exists"
                 else
                   echo "Cloudflare dns record for $domain is not found"


### PR DESCRIPTION
## What does this PR do?
Change the logic when dns_record_id equals "null".

if `dns_record_id` equals `"null"`, it will also proceed to the `already exists`.
